### PR TITLE
fix: allow by-passing of required statement, for --help and others

### DIFF
--- a/src/clice-demo/main.cpp
+++ b/src/clice-demo/main.cpp
@@ -29,7 +29,7 @@ void generateCWL() {
         .description    = "demonstration tool of clice options",
         .executableName = clice::argv0,
     };
-    std::cout << convertToCWL(toolInfo);
+    std::cout << convertToCWL(toolInfo) << "\n";
     exit(0);
 }
 

--- a/src/clice-demo/main.cpp
+++ b/src/clice-demo/main.cpp
@@ -8,14 +8,16 @@ namespace {
 auto cliHelp    = clice::Argument{ .args   = "--help",
                                    .desc   = "prints the help page",
                                    .cb     = []{ std::cout << clice::generateHelp(); exit(0); },
+                                   .tags   = {"ignore-required"},
                                  };
 
 void generateCWL();
 auto cliCWL     = clice::Argument{ .args   = "--cwl-description",
-                                   .id     = "<files>...",
+                                   .id     = "<command>...",
                                    .desc   = "prints a cwl-description of a certain subcommand",
                                    .value  = std::vector<std::string>{},
                                    .cb     = generateCWL,
+                                   .tags   = {"ignore-required"},
                                  };
 void generateCWL() {
     auto toolInfo = clice::generateCWL(*cliCWL);

--- a/src/clice/generateCWL.h
+++ b/src/clice/generateCWL.h
@@ -105,7 +105,7 @@ inline auto generateCWL(std::vector<std::string> subtool) -> tdl::ToolInfo {
             }
 
             auto node = tdl::Node {
-                .name        = arg->args[0],
+                .name        = (arg->args.empty()?std::string{}:arg->args[0]),
                 .description = arg->desc,
                 .tags        = {arg->tags.begin(), arg->tags.end()},
                 .value       = tdl::StringValueList{},
@@ -140,13 +140,13 @@ inline auto generateCWL(std::vector<std::string> subtool) -> tdl::ToolInfo {
                 node.value = tdl::StringValueList{};
 
             } else {
-                std::cerr << "unknown on how to convert " + arg->args[0] + " from clice to tdl\n";
+                std::cerr << "unknown on how to convert " + arg->id + " from clice to tdl\n";
                 continue;
             }
 
             res.push_back(node);
             info.cliMapping.push_back({
-                .optionIdentifier = arg->args[0],
+                .optionIdentifier = (arg->args.empty()?std::string{}:arg->args[0]),
                 .referenceName    = node.name,
             });
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Help and command options can now be executed without requiring all mandatory arguments, improving flexibility in command-line usage.

- **Refactor**
  - Improved the order and handling of command-line argument callbacks, ensuring options tagged to ignore required arguments are processed appropriately.
  - Enhanced error handling and output formatting for command-line tools to prevent runtime issues and improve message clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->