### PR TITLE
fix: improved handling when mapping has invalid key

### DIFF
--- a/src/clice/Argument.h
+++ b/src/clice/Argument.h
@@ -228,6 +228,17 @@ struct Argument {
                 } else if constexpr (std::is_arithmetic_v<T>) {
                     arg.fromString = [&](std::string_view s) {
                         if (desc.mapping) {
+                            if (!desc.mapping->contains(std::string{s})) {
+                                std::string validValues{};
+                                for (auto [key, value] : *desc.mapping) {
+                                    validValues += key + ", ";
+                                }
+                                if (validValues.size() > 2) {
+                                    validValues.pop_back();
+                                    validValues.pop_back();
+                                }
+                                throw std::runtime_error{"invalid value \"" + std::string{s} + "\". Valid values are: [ " + validValues + " ]"};
+                            }
                             desc.value = desc.mapping->at(std::string{s});
                         } else {
                             if (desc.suffix) {
@@ -247,6 +258,18 @@ struct Argument {
                                      || std::is_enum_v<T>) {
                     arg.fromString = [&](std::string_view s) {
                         if (desc.mapping) {
+                            if (!desc.mapping->contains(std::string{s})) {
+                                std::string validValues{};
+                                for (auto [key, value] : *desc.mapping) {
+                                    validValues += key + ", ";
+                                }
+                                if (validValues.size() > 2) {
+                                    validValues.pop_back();
+                                    validValues.pop_back();
+                                }
+                                throw std::runtime_error{"invalid value \"" + std::string{s} + "\". Valid values are: [ " + validValues + " ]"};
+                            }
+
                             desc.value = desc.mapping->at(std::string{s});
                         } else {
                             desc.value = parseFromString<T>(s);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid mapped argument inputs by providing clear error messages listing valid options when an unknown key is entered. Invalid inputs are now explicitly rejected to prevent unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->